### PR TITLE
Chore: Improve .gitignore for service account keys and Android builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,11 +43,12 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+/android/build
 
 # Firebase Admin SDK
-functions/service-account-key.json
-service-account-key.json
-**/service-account-key.json
+functions/service-account-key*.json
+service-account-key*.json
+**/service-account-key*.json
 
 # Environment files (keep .env.example)
 .env


### PR DESCRIPTION
## Summary
Improved `.gitignore` patterns to properly exclude all service account key variants and Android build artifacts, preventing sensitive credentials from being accidentally committed.

## Changes
- **Service account keys**: `service-account-key.json` → `service-account-key*.json`
  - Now catches `-dev`, `-staging`, and any other variants
  - Prevents accidental commits of sensitive Firebase credentials
- **Android builds**: Added `/android/build` to ignored paths
  - Excludes build artifacts from version control

## Security Impact
🔒 **Critical**: This change ensures that service account keys for all environments (dev, staging, prod) are properly excluded from git, preventing potential credential leaks.

## Before
```
functions/service-account-key.json     ✅ Ignored
functions/service-account-key-dev.json ❌ Not ignored
functions/service-account-key-staging.json ❌ Not ignored
```

## After
```
functions/service-account-key.json     ✅ Ignored
functions/service-account-key-dev.json ✅ Ignored
functions/service-account-key-staging.json ✅ Ignored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)