### PR TITLE
chore: update bloc packages to resolve hydrated_bloc deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,11 +43,12 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+/android/build
 
 # Firebase Admin SDK
-functions/service-account-key.json
-service-account-key.json
-**/service-account-key.json
+functions/service-account-key*.json
+service-account-key*.json
+**/service-account-key*.json
 
 # Environment files (keep .env.example)
 .env

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,8 +52,10 @@ Future<void> main() async {
   // Initialize HydratedBloc storage
   HydratedBloc.storage = await HydratedStorage.build(
     storageDirectory: kIsWeb
-        ? HydratedStorage.webStorageDirectory
-        : await getApplicationDocumentsDirectory(),
+        ? HydratedStorageDirectory.web
+        : HydratedStorageDirectory(
+            (await getApplicationDocumentsDirectory()).path,
+          ),
   );
 
   // Set custom BLoC observer

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,18 +61,18 @@ packages:
     dependency: "direct main"
     description:
       name: bloc
-      sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
+      sha256: e18b8e7825e9921d67a6d256dba0b6015ece8a577eb0a411845c46a352994d78
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.4"
+    version: "9.0.1"
   bloc_test:
     dependency: "direct dev"
     description:
       name: bloc_test
-      sha256: "165a6ec950d9252ebe36dc5335f2e6eb13055f33d56db0eeb7642768849b43d2"
+      sha256: "1dd549e58be35148bc22a9135962106aa29334bc1e3f285994946a1057b29d7b"
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.7"
+    version: "10.0.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -570,10 +570,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
+      sha256: cf51747952201a455a1c840f8171d273be009b932c75093020f9af64f2123e38
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.6"
+    version: "9.1.1"
   flutter_cache_manager:
     dependency: transitive
     description:
@@ -730,14 +730,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  hive:
+  hive_ce:
     dependency: transitive
     description:
-      name: hive
-      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
+      name: hive_ce
+      sha256: d678b1b2e315c18cd7ed8fd79eda25d70a1f3852d6988bfe5461cffe260c60aa
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.14.0"
   http:
     dependency: transitive
     description:
@@ -766,10 +766,10 @@ packages:
     dependency: "direct main"
     description:
       name: hydrated_bloc
-      sha256: af35b357739fe41728df10bec03aad422cdc725a1e702e03af9d2a41ea05160c
+      sha256: f359a1135cc2eaddb53eeb21c8f915a149b9bdb80d01fda27c6f4e333db0cf2f
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.5"
+    version: "10.1.1"
   image_picker:
     dependency: "direct main"
     description:
@@ -855,6 +855,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  isolate_channel:
+    dependency: transitive
+    description:
+      name: isolate_channel
+      sha256: f3d36f783b301e6b312c3450eeb2656b0e7d1db81331af2a151d9083a3f6b18d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,10 +48,10 @@ dependencies:
   google_fonts: ^6.0.0
   shimmer: ^3.0.0
   flutter_staggered_grid_view: ^0.7.0
-  flutter_bloc: ^8.1.5
-  bloc: ^8.1.4
+  flutter_bloc: ^9.0.0
+  bloc: ^9.0.0
   equatable: ^2.0.5
-  hydrated_bloc: ^9.1.5
+  hydrated_bloc: ^10.1.1
   path_provider: ^2.1.3
   url_launcher: ^6.3.1
   share_plus: ^10.1.4
@@ -73,7 +73,7 @@ dev_dependencies:
   flutter_lints: ^5.0.0
 
   # Testing packages
-  bloc_test: ^9.1.7
+  bloc_test: ^10.0.0
   mockito: ^5.4.4
   mocktail: ^1.0.0
   build_runner: ^2.4.9


### PR DESCRIPTION
## Summary
- Updated `hydrated_bloc` from 9.1.5 to 10.1.1 to resolve VS Code workspace warning
- Updated entire bloc ecosystem to compatible versions:
  - `bloc`: 8.1.4 → 9.0.1
  - `flutter_bloc`: 8.1.6 → 9.1.1
  - `bloc_test`: 9.1.7 → 10.0.0
- Migrated HydratedStorage initialization to use `HydratedStorageDirectory` for web/mobile compatibility
- Transitive dependency migration: hive → hive_ce

## Test plan
- [x] All unit tests pass (424 tests)
- [x] Flutter analyze passes with no issues
- [x] Code is properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)