### PR TITLE
fix(ci): build only prod flavor for Android CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,16 +132,17 @@ jobs:
 
       - name: Create Firebase config from secrets
         run: |
-          echo "${{ secrets.ANDROID_FIREBASE_CONFIG }}" | base64 -d > android/app/google-services.json
+          mkdir -p android/app/src/prod
+          echo "${{ secrets.ANDROID_FIREBASE_CONFIG }}" | base64 -d > android/app/src/prod/google-services.json
 
-      - name: Build Android APK
-        run: flutter build apk --release
+      - name: Build Android APK (prod flavor only)
+        run: flutter build apk --release --flavor prod
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: android-apk
-          path: build/app/outputs/flutter-apk/app-release.apk
+          name: android-apk-prod
+          path: build/app/outputs/flutter-apk/app-prod-release.apk
 
   build-web:
     name: Build Web


### PR DESCRIPTION
## Summary

Fix Android CI build failure caused by attempting to build all Android flavors without providing all required Firebase configuration files.

### Problem

The Android build in CI was failing with:
```
Execution failed for task ':app:processDevReleaseGoogleServices'.
> No matching client found for package name 'com.backdrpfm.app.dev'
```

**Root cause:**
- Android app defines 3 product flavors: `dev`, `staging`, `prod`
- `flutter build apk --release` builds **ALL flavors** by default
- CI only provides one `google-services.json` file via secrets
- Build failed when trying to process the `dev` flavor config

### Solution

Build only the `prod` flavor in CI:
- ✅ Add `--flavor prod` flag to build command
- ✅ Place config file in flavor-specific directory: `android/app/src/prod/google-services.json`
- ✅ Update artifact path to match flavor output: `app-prod-release.apk`

### Changes

**`.github/workflows/ci.yml`:**
```yaml
# Before
- name: Create Firebase config from secrets
  run: |
    echo "${{ secrets.ANDROID_FIREBASE_CONFIG }}" | base64 -d > android/app/google-services.json

- name: Build Android APK
  run: flutter build apk --release

# After
- name: Create Firebase config from secrets
  run: |
    mkdir -p android/app/src/prod
    echo "${{ secrets.ANDROID_FIREBASE_CONFIG }}" | base64 -d > android/app/src/prod/google-services.json

- name: Build Android APK (prod flavor only)
  run: flutter build apk --release --flavor prod
```

### Benefits

- ✅ CI builds successfully without needing all three Firebase configs
- ✅ Produces production-ready APK
- ✅ Faster builds (only one flavor instead of three)
- ✅ Cleaner artifact naming (`android-apk-prod`)

### Testing

- [x] Pre-commit hooks passed locally (analyze, format, tests)
- [x] Commit follows conventional commit format
- [x] CI will validate the fix when PR is opened

## Related

- Fixes Android CI build failure on PR #10
- Relates to multi-environment Firebase setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)